### PR TITLE
Adds metadata fields to expert picture

### DIFF
--- a/schemas/expert.js
+++ b/schemas/expert.js
@@ -36,10 +36,15 @@ export default {
 		{
 			name: 'picture',
 			title: 'Picture',
+			description: 'A headshot or other avatar for this expert',
 			type: 'image',
 			options: {
 				hotspot: true,
 			},
+			fields: [
+				{name: 'caption', type: 'string', title: 'Caption', description: 'Used for the alternative text'},
+				{name: 'foo', type: 'string', title: 'Foo', description: 'Please just say "bar"'}
+			]
 		},
 		{
 			name: 'cv',

--- a/schemas/expert.js
+++ b/schemas/expert.js
@@ -42,8 +42,8 @@ export default {
 				hotspot: true,
 			},
 			fields: [
-				{name: 'caption', type: 'string', title: 'Caption', description: 'Used for the alternative text'},
-				{name: 'foo', type: 'string', title: 'Foo', description: 'Please just say "bar"'}
+				{name: 'caption', type: 'string', title: 'Caption', description: 'This is a descriptive caption, not the alt text'},
+				{name: 'alt', type: 'string', title: 'Alternate text', description: 'This will be used for the alternative text'}
 			]
 		},
 		{


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This tries to add metadata fields to images, in the hope of building out a more robust media library functionality.

#### Helpful background context (if appropriate)
The default image selection tool in Sanity seems a little light - no built-in fields for alt text, etc. This is an attempt to correct that by adding fields directly to images.

#### How can a reviewer manually see the effects of these changes?
Check out the Sanity Studio while this version of the application is deployed there

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
